### PR TITLE
Fixes input loss by implementing a quit command properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ add_executable(sourcebound
         include/ecs/RenderSystem.h
         src/ecs/RenderSystem.cpp
         tests/mocks/MockRenderer.h
+        include/gamestate/QuitCommand.h
+        src/gamestate/QuitCommand.cpp
 )
 
 add_executable(unit_tests
@@ -122,6 +124,8 @@ add_executable(unit_tests
         src/ecs/RenderSystem.cpp
         tests/mocks/MockRenderer.h
         tests/render_system_tests.cpp
+        src/gamestate/QuitCommand.cpp
+        tests/quit_command_test.cpp
 )
 
 target_include_directories(sourcebound PUBLIC

--- a/include/gamestate/GameWorld.h
+++ b/include/gamestate/GameWorld.h
@@ -113,11 +113,19 @@ class GameWorld final : public IGameWorld, public std::enable_shared_from_this<G
     return component_manager_->has_component<T>(entity);
   }
 
+  [[nodiscard]] bool should_exit() const override {
+    return should_exit_;
+  }
+  void request_exit() override {
+    should_exit_ = true;
+  }
+
  private:
   std::shared_ptr<ecs::IEntityManager> entity_manager_;
   std::shared_ptr<ecs::ComponentManager> component_manager_;
   std::shared_ptr<ecs::ISystemManager> system_manager_;
   std::shared_ptr<ICommandQueue> cmd_queue_;
+  bool should_exit_ = false;
 };
 
 }  // namespace sb::gamestate

--- a/include/gamestate/IGameWorld.h
+++ b/include/gamestate/IGameWorld.h
@@ -53,6 +53,8 @@ public:
   virtual void update(float delta_time) = 0;
   virtual void process_events() = 0;
   [[nodiscard]] virtual bool is_alive(Entity entity) const = 0;
+  [[nodiscard]] virtual bool should_exit() const = 0;
+  virtual void request_exit() = 0;
 };
 
 } // namespace sb::ecs

--- a/include/gamestate/QuitCommand.h
+++ b/include/gamestate/QuitCommand.h
@@ -1,0 +1,51 @@
+//
+// Created by Jace Shultz on 7/21/2025.
+// Copyright (c) 2025 by spaceofjace. All rights reserved.
+//
+
+/**
+ * @file QuitCommand.h
+ * @ingroup gamestate
+ * @brief Defines a command that requests the game world to initiate shutdown.
+ *
+ * Used to signal that the main game loop should exit, typically triggered by input bindings
+ * (e.g., Escape key) or system events (e.g., SDL_EVENT_QUIT). This command pattern allows
+ * input-driven exit behavior without exposing window internals.
+ * 
+ * @author Jace Shultz
+ * @date 7/21/2025
+ */
+#ifndef QUITCOMMAND_H
+#define QUITCOMMAND_H
+#include "GameWorld.h"
+#include "ICommand.h"
+namespace sb::gamestate {
+/**
+ * @class QuitCommand
+ * @ingroup gamestate
+ * @brief Represents a command to signal the game should exit.
+ *
+ * Typically triggered via Escape key or system events like SDL_EVENT_QUIT.
+ * Calls GameWorld::request_exit to notify the main loop to terminate cleanly.
+ */
+class QuitCommand final : public ICommand {
+public:
+/**
+ * @brief Returns the name identifier of the command.
+ * @return String representing the command name.
+ */
+  [[nodiscard]] std::string name() const override {return name_;}
+
+  QuitCommand() = default;
+
+/**
+   * @brief Applies the quit logic to the game world.
+   * @param world The active game world instance.
+   */
+  void apply(std::shared_ptr<GameWorld> world) override;
+
+private:
+  static const std::string name_;
+};
+}// namespace sb::gamestate
+#endif //QUITCOMMAND_H

--- a/include/input/InputAction.h
+++ b/include/input/InputAction.h
@@ -27,6 +27,7 @@ enum class InputAction {
   MoveRight,
   LaunchBall,
   PauseGame,
+  QuitGame,
 };
 } // namespace sb::input
 #endif //INPUTACTION_H

--- a/include/input/InputCode.h
+++ b/include/input/InputCode.h
@@ -85,6 +85,8 @@ using InputData = std::variant<
  * @see InputData
  */
 struct InputCode {
+  static constexpr int kQuitCode = 0xFF;
+
   DeviceType device{ DeviceType::Invalid };
   InputKind kind{ InputKind::Invalid };
   InputData data;
@@ -109,6 +111,14 @@ struct InputCode {
 
   static InputCode FromGamepadAxis(SDL_GamepadAxis axis) {
     return { DeviceType::Gamepad, InputKind::Axis, axis };
+  }
+
+  /**
+ * @brief Creates a virtual InputCode used to represent system-initiated quit requests.
+ * @return A synthetic InputCode that maps to InputAction::QuitGame.
+ */
+  static InputCode VirtualQuit() {
+    return { DeviceType::Invalid, InputKind::Button, static_cast<Uint8>(kQuitCode) };
   }
 
   [[nodiscard]] bool is_axis() const { return kind == InputKind::Axis; }

--- a/src/gamestate/QuitCommand.cpp
+++ b/src/gamestate/QuitCommand.cpp
@@ -1,0 +1,14 @@
+//
+// Created by Jace Shultz on 7/21/2025.
+// Copyright (c) 2025 by spaceofjace. All rights reserved.
+//
+
+#include "../../include/gamestate/QuitCommand.h"
+#include "../../include/ecs/components/Components.h"
+
+const std::string sb::gamestate::QuitCommand::name_ = "QuitCommand";
+
+void sb::gamestate::QuitCommand::apply(const std::shared_ptr<GameWorld> world) {
+  world->request_exit();
+  log::Logger::info("[Command Applied]: " + name_);
+}

--- a/src/input/HardCodedBindingMap.cpp
+++ b/src/input/HardCodedBindingMap.cpp
@@ -5,6 +5,9 @@
 
 #include "../../include/input/HardcodedBindingMap.h"
 sb::input::InputAction sb::input::HardcodedBindingMap::resolve(const InputCode& input) const {
+  if (input == InputCode::VirtualQuit()) {
+    return InputAction::QuitGame;
+  }
   auto found_binding = this->bindings_.find(input);
   if (found_binding != this->bindings_.end()) {
     return found_binding->second;
@@ -20,6 +23,7 @@ void sb::input::HardcodedBindingMap::load_bindings(const std::string& path) {
   bindings_.emplace(InputCode::FromKeyboard(SDL_SCANCODE_LEFT), InputAction::MoveLeft);
   bindings_.emplace(InputCode::FromKeyboard(SDL_SCANCODE_RIGHT), InputAction::MoveRight);
   bindings_.emplace(InputCode::FromKeyboard(SDL_SCANCODE_SPACE), InputAction::LaunchBall);
+  bindings_.emplace(InputCode::FromKeyboard(SDL_SCANCODE_ESCAPE), InputAction::QuitGame);
 }
 void sb::input::HardcodedBindingMap::save_bindings(const std::string& path) const {
   //no-op

--- a/src/input/InputNormalizer.cpp
+++ b/src/input/InputNormalizer.cpp
@@ -6,6 +6,7 @@
 #include "../../include/input/InputNormalizer.h"
 
 #include "../../include/gamestate/PlayerMoveCommand.h"
+#include "../../include/gamestate/QuitCommand.h"
 void sb::input::InputNormalizer::normalize_input(const InputCode& code, float value) {
   auto action = this->binding_map_->resolve(code);
 
@@ -22,6 +23,12 @@ void sb::input::InputNormalizer::normalize_input(const InputCode& code, float va
       command_queue_->enqueue(move(move_right_command));
       break;
     }
+    case InputAction::QuitGame:{
+      auto quit_command = std::make_unique<gamestate::QuitCommand>();
+      command_queue_->enqueue(move(quit_command));
+      break;
+    }
+    case InputAction::LaunchBall:
     case InputAction::None:
     default:
       break;

--- a/src/input/KeyboardHandler.cpp
+++ b/src/input/KeyboardHandler.cpp
@@ -29,7 +29,7 @@ void KeyboardHandler::poll_inputs() {
     }
     else if (event.type == SDL_EVENT_QUIT) {
       quit = true;
-      //Do I need a QuitCommand?
+      this->normalizer().normalize_input(InputCode::VirtualQuit(), 1.0F);
     }
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,9 +54,6 @@ int main() {
     return 1;
   }
 
-  TimePoint lastFrameTime = Clock::now();
-  bool isRunning = true;
-
   world->register_component<Velocity>();
   world->register_component<Paddle>();
   world->register_component<Ball>();
@@ -85,24 +82,23 @@ int main() {
   world->add_component(ball, RenderableSimpleShape{sb::rendering::Colors::cyan, SimpleShapeType::Circle, true});
   world->add_component(ball, Velocity{0, 0});
 
-  while (isRunning) {
-    SDL_Event sdl_event;
+  TimePoint lastFrameTime = Clock::now();
 
-    while (SDL_PollEvent(&sdl_event)) {
-      if (sdl_event.type == SDL_EVENT_QUIT) {
-        isRunning = false;
-      }
-    }
-
+  while (true) {
     TimePoint currentFrameTime = Clock::now();
     std::chrono::duration<float> elapsed = currentFrameTime - lastFrameTime;
-    float deltaTime = elapsed.count();
+    const float deltaTime = elapsed.count();
     lastFrameTime = currentFrameTime;
 
     // Main per-frame execution
     input.poll_inputs();
     renderer->clear();
     world->step(deltaTime);
+
+    if (world->should_exit()) {
+      break;
+    }
+
     world->update(deltaTime);
     renderer->present();
   }

--- a/tests/hardcoded_bindings_tests.cpp
+++ b/tests/hardcoded_bindings_tests.cpp
@@ -35,4 +35,7 @@ TEST(HardcodedBindingMapTest, LoadBindingsSetsDefaultKeys) {
             InputAction::MoveRight);
   EXPECT_EQ(bindings.resolve(sb::input::InputCode::FromKeyboard(SDL_SCANCODE_SPACE)),
             InputAction::LaunchBall);
+  EXPECT_EQ(bindings.resolve(sb::input::InputCode::FromKeyboard(SDL_SCANCODE_ESCAPE)),
+            InputAction::QuitGame);
+  EXPECT_EQ(bindings.resolve(InputCode::VirtualQuit()), InputAction::QuitGame);
 }

--- a/tests/quit_command_test.cpp
+++ b/tests/quit_command_test.cpp
@@ -1,0 +1,29 @@
+//
+// Created by Jace Shultz on 7/21/2025.
+// Copyright (c) 2025 by spaceofjace. All rights reserved.
+//
+
+#include "../../../include/gamestate/QuitCommand.h"
+#include "../../../include/gamestate/GameWorld.h"
+#include "mocks/MockCommandQueue.h"
+#include "mocks/MockComponentManager.h"
+#include "mocks/MockEntityManager.h"
+#include "mocks/MockSystemManager.h"
+#include "gtest/gtest.h"
+
+TEST(QuitCommandTest, CallsRequestExitOnGameWorld) {
+  using namespace sb::gamestate;
+
+  auto em = std::make_shared<MockEntityManager>();
+  auto cm = std::make_shared<ComponentManager>();   //real component manager
+  auto sm = std::make_shared<MockSystemManager>();
+  auto cq = std::make_shared<MockCommandQueue>();
+  auto gw = std::make_shared<GameWorld>(em, cm, sm, cq);
+
+  EXPECT_FALSE(gw->should_exit());
+
+  QuitCommand cmd;
+  cmd.apply(gw);
+
+  EXPECT_TRUE(gw->should_exit());
+}


### PR DESCRIPTION
Having not worked with SDL much, I wasn't considering accidentally clearing the inputs by checking for an SDL_QUIT_EVENT external to the input polling (though it obviously makes sense.)  I was trying to defer additional commands to the game loop milestone, but per my comments, I knew it would be a more proper way top manage inputs, as well as provide an option to bind quit to a key press (ESC).

Technically, there should be a confirmation check on quit, but that will be a future polish item.

I tracked this as a "bug" though it did ultimately turn out to be a feature to implement.